### PR TITLE
Discord Role Mention Support + Get rid of Ban webhook check.

### DIFF
--- a/sbpp_discord.sp
+++ b/sbpp_discord.sp
@@ -333,6 +333,7 @@ void GetEndpoint(char[] sBuffer, int iBufferSize, int iType)
 		strcopy(sBuffer, iBufferSize, sEndpoints[iType]);
 		return;
 	}
+	strcopy(sBuffer, iBufferSize, "");
 }
 
 void GetCommType(char[] sBuffer, int iBufferSize, int iType)

--- a/sbpp_discord.sp
+++ b/sbpp_discord.sp
@@ -62,7 +62,7 @@ public void OnPluginStart()
 
 	ProfilePictureURL = CreateConVar("sbpp_discord_pp_url", "https://sbpp.github.io/img/favicons/android-chrome-512x512.png", "A URL pointing to the profile picture for the webhook.");
 
-	DiscordRoleID = CreateConVar("sbpp_discord_roleid", "", "The Discord role id that you would like mentioned when recieving a report. Leave empty to disable.");
+	DiscordRoleID = CreateConVar("sbpp_discord_roleid", "", "The Discord role id that you would like mentioned when receiving a report. Leave empty to disable.");
 
 	AutoExecConfig(true,"sbpp_discord");
 


### PR DESCRIPTION
I've made changes that allow for a specific role to be mentioned on discord when a player creates a report (optional, configurable via convar). 
I also got rid of the if statement that checks if the ban webhook convar was empty, and instead added a check before every report function is called to ensure the webhook for each according convar isn't empty. This allows you to only use one reporting feature of the plugin without needing a ban webhook set.