### PR TITLE
Correct OnHTTPRequestComplete return type

### DIFF
--- a/sbpp_discord.sp
+++ b/sbpp_discord.sp
@@ -282,7 +282,7 @@ void SendReport(int iClient, int iTarget, const char[] sReason, int iType = Ban,
 		LogError("HTTP request failed for %s against %s", sAuthor, sTarget);
 }
 
-public int OnHTTPRequestComplete(Handle hRequest, bool bFailure, bool bRequestSuccessful, EHTTPStatusCode eStatusCode, int iClient, int iTarget)
+public void OnHTTPRequestComplete(Handle hRequest, bool bFailure, bool bRequestSuccessful, EHTTPStatusCode eStatusCode, int iClient, int iTarget)
 {
 	if (!bRequestSuccessful || eStatusCode != k_EHTTPStatusCode204NoContent)
 	{


### PR DESCRIPTION
Currently, OnHTTPRequestComplete is declared with an int return while it doesn't even return anything. It shouldn't either, but this causes a warning during compilation.